### PR TITLE
fix(x/evidence): validator should be slashed even if a validator is not bonded in active set

### DIFF
--- a/x/evidence/keeper/infraction.go
+++ b/x/evidence/keeper/infraction.go
@@ -33,7 +33,7 @@ func (k Keeper) handleEquivocationEvidence(ctx context.Context, evidence *types.
 	if err != nil {
 		return err
 	}
-	if validator == nil || validator.IsUnbonded() {
+	if validator == nil {
 		// Defensive: Simulation doesn't take unbonding periods into account, and
 		// CometBFT might break this assumption at some point.
 		return nil

--- a/x/evidence/types/expected_keepers.go
+++ b/x/evidence/types/expected_keepers.go
@@ -17,7 +17,6 @@ type (
 	// ValidatorI expected validator interface
 	ValidatorI interface {
 		IsJailed() bool                          // whether the validator is jailed
-		IsUnbonded() bool                        // whether the validator is unbonded
 		ConsPubKey() (cryptotypes.PubKey, error) // validation consensus pubkey (cryptotypes.PubKey)
 		GetConsAddr() ([]byte, error)            // validation consensus address
 	}

--- a/x/slashing/types/expected_keepers.go
+++ b/x/slashing/types/expected_keepers.go
@@ -37,7 +37,6 @@ type ParamSubspace interface {
 
 type ValidatorI interface {
 	IsJailed() bool                          // whether the validator is jailed
-	IsUnbonded() bool                        // whether the validator is unbonded
 	ConsPubKey() (cryptotypes.PubKey, error) // validation consensus pubkey (cryptotypes.PubKey)
 	GetConsAddr() ([]byte, error)            // validation consensus address
 }


### PR DESCRIPTION
### Context
1. Outside of x/staking, there is only one line of code in the x/evidence module that checks whether a validator is bonded/unbonding/unbonded in the Cosmos SDK.
2. In the x/evidence module, the handleEquivocationEvidence() function prevents evidence submission if a validator is unbonded.
3. Currently, in Mitosis Chain, the consensus layer does not separately distinguish the unbonding state. When a validator is removed from the active validator set, it is treated as unbonded.
4. Logically, there is an unbonding period for both collateral and staking. However, we are not "defining" the validator's "unbonding" state separately from the unbonding of assets.

### Problem
If a validator is removed from the active set in the brief interval between when a double signing occurs and when evidence is submitted, the evidence may not be processed in the handleEquivocationEvidence() function.

### Solution
In my opinion, it wouldn't be a significant issue to allow evidence submission for past actions at all times by removing the check for whether a validator is unbonded in the handleEquivocationEvidence() function.